### PR TITLE
플레이어 이동 구현

### DIFF
--- a/Engine/Core.cpp
+++ b/Engine/Core.cpp
@@ -27,19 +27,25 @@ void MIYABI::Core::BootManagers()
 	InputManager::GetInstance().Initialize(static_cast<HWND>(GetWindowHandle()));
 
 	SoundManager::GetInstance().Initialize(); // 사운드 매니저 초기화
-	SoundManager::GetInstance().PlaySoundOnce("TestSound.ogg");
+	SoundManager::GetInstance().PlaySoundOnce("TestSound.ogg"); 
+
 }
 
 
 // https://learn.microsoft.com/ko-kr/windows/win32/inputdev/virtual-key-codes
+// F10이 안먹는데 확인좀 - 준혁
 bool MIYABI::Core::KeyCommandMapping()
 {
 	m_keyCommandMap[VK_F1] = "F1";
 	m_keyCommandMap[VK_F2] = "F2";
 	m_keyCommandMap[VK_F3] = "F3";
 	m_keyCommandMap[VK_F4] = "F4";
-	m_keyCommandMap[VK_F9] = "DebugMode";
-	m_keyCommandMap[VK_F10] = "Skip";
+	m_keyCommandMap[VK_F8] = "DebugMode";
+	m_keyCommandMap[VK_F12] = "Skip";
+	m_keyCommandMap['W'] = "Go";
+	m_keyCommandMap['S'] = "Back";
+	m_keyCommandMap['A'] = "Left";
+	m_keyCommandMap['D'] = "Right";
 	m_keyCommandMap[VK_ESCAPE] = "Escape"; // 게임 일시 정지/재개
 
 	return true;
@@ -72,6 +78,38 @@ void MIYABI::Core::ProcessKeyInput(InputManager& input)
 			}
 		}
 		else if (vk == VK_F2 && input.GetKeyDown(vk))
+		{
+			auto it = m_keyCommandMap.find(vk);
+			if (it != m_keyCommandMap.end())
+			{
+				SendMessage(it->second);
+			}
+		}
+		else if (vk == 'W' && input.GetKeyDown(vk))
+		{
+			auto it = m_keyCommandMap.find(vk);
+			if (it != m_keyCommandMap.end())
+			{
+				SendMessage(it->second);
+			}
+		}
+		else if (vk == 'A' && input.GetKeyDown(vk))
+		{
+			auto it = m_keyCommandMap.find(vk);
+			if (it != m_keyCommandMap.end())
+			{
+				SendMessage(it->second);
+			}
+		}
+		else if (vk == 'S' && input.GetKeyDown(vk))
+		{
+			auto it = m_keyCommandMap.find(vk);
+			if (it != m_keyCommandMap.end())
+			{
+				SendMessage(it->second);
+			}
+		}
+		else if (vk == 'D' && input.GetKeyDown(vk))
 		{
 			auto it = m_keyCommandMap.find(vk);
 			if (it != m_keyCommandMap.end())

--- a/Engine/SceneBase.h
+++ b/Engine/SceneBase.h
@@ -18,6 +18,7 @@ private:
 protected:
 	std::vector<std::unique_ptr<Object>> m_objectList;
 	//render 에 대해서 따로 관리 생각
+	std::unordered_map<std::string, std::function<void()>> m_commandMap;
 	
 public:
 	SceneBase() = default;
@@ -35,6 +36,27 @@ public:
 	int GetObjectCount() { return m_objectList.size(); }
 
 
-	virtual void OnCommand(std::string& cmd) = 0; // 입력처리
+	virtual void OnEnter() = 0;
 
+	virtual void OnLeave() = 0;
+
+	virtual void KeyCommandMapping() = 0;
+
+	virtual void Reset()
+	{
+		m_objectList.clear(); 
+	}
+
+	virtual void OnCommand(std::string& cmd)  // 입력처리
+	{
+		auto it = m_commandMap.find(cmd);
+		if (it != m_commandMap.end())
+		{
+			it->second(); // 함수 실행
+		}
+		else
+		{
+			std::cout << "Unknown Command: " << cmd << std::endl;
+		}
+	}
 };

--- a/Engine/SceneManager.cpp
+++ b/Engine/SceneManager.cpp
@@ -88,3 +88,13 @@ void SceneManager::OnCommand(std::string& cmd)
 }
 
 
+void SceneManager::InitializeAllScenes()
+{
+	std::cout << "casd";
+	for (auto& scene : m_sceneList)
+	{
+		if (scene)
+			scene->Initialize();
+	}
+}
+

--- a/Engine/SceneManager.h
+++ b/Engine/SceneManager.h
@@ -57,6 +57,7 @@ public:
 
 	void OnCommand(std::string& cmd);			// 입력처리
 
+	void InitializeAllScenes();
 
 };
 
@@ -69,11 +70,14 @@ void SceneManager::ChangeScene(const T& index) {
 		//m_currentSceneIndex = m_sceneNameMap[index]
 
 		if (auto it = m_sceneNameMap.find(index); it != m_sceneNameMap.end()) {
+			m_sceneList[m_currentSceneIndex]->OnLeave();
 			m_currentSceneIndex = it->second;
+			m_sceneList[m_currentSceneIndex]->OnEnter();
 		}
 		else { std::cout << "Error: invalid Scene Id" << std::endl; return; }
 
 	}
+
 	else if constexpr (std::is_same_v<T, int>) {
 		if (index >= 0 && index < static_cast<int>(m_sceneList.size())) {
 			m_currentSceneIndex = index;

--- a/GameFrameWork/GameManager.cpp
+++ b/GameFrameWork/GameManager.cpp
@@ -19,6 +19,12 @@ void GameManager::SetGameScene() {
 	SceneManager::GetInstance().AddScene("Title", std::make_unique<TitleScene>()); // index 0 
 	SceneManager::GetInstance().AddScene("Game1", std::make_unique<GameScene>());  // index 1 
 	//SceneManager::GetInstance().AddScene("Ending", std::make_unique<EndingScene>());
+
+
+
+
+
+	SceneManager::GetInstance().InitializeAllScenes();    //일단 테스트
 }
 
 void GameManager::GetModeState()

--- a/GameFrameWork/GameScene.cpp
+++ b/GameFrameWork/GameScene.cpp
@@ -3,12 +3,13 @@
 
 void GameScene::Initialize()
 {
-	//std::cout << "Game Scene 초기화 완료" << std::endl;
+	std::cout << "Game Scene Init" << std::endl;
+	KeyCommandMapping();
 	// 초기화를 매번 이렇게 할 순 없긴해
-	auto playerObject = std::make_unique<Player>(
-		600.0f, 300.0f, 50.0f, 50.0f, DirectX::XMFLOAT4(1.0f, 0.0f, 0.0f, 1.0f) // 녹색
-	);
-	m_objectList.push_back(std::move(playerObject));
+// 	auto playerObject = std::make_unique<Player>(
+// 		600.0f, 300.0f, 50.0f, 50.0f, DirectX::XMFLOAT4(1.0f, 0.0f, 0.0f, 1.0f) // 녹색
+// 	);
+// 	m_objectList.push_back(std::move(playerObject));
 
 	//실행 중 동적 생성/삭제는 어떻게?
 }
@@ -35,9 +36,85 @@ void GameScene::LateUpdate(double deltaTime)
 	}*/
 }
 
-void GameScene::OnCommand(std::string& cmd)
+void GameScene::OnEnter()
 {
+
+	std::cout << "Game1 Scene OnEnter" << std::endl;
+	auto playerObject = std::make_unique<Player>(
+		600.0f, 300.0f, 50.0f, 50.0f, DirectX::XMFLOAT4(1.0f, 0.0f, 0.0f, 1.0f) // 녹색
+	);
+	m_player = playerObject.get();
+	m_objectList.push_back(std::move(playerObject));
+	std::cout << m_objectList.size() << std::endl;
 
 }
 
+void GameScene::OnLeave()
+{
+	std::cout << "Game1 Scene Left" << std::endl;
+	Reset();
+}
+
+void GameScene::OnCommand(std::string& cmd)
+{
+	auto it = m_commandMap.find(cmd);
+	if (it != m_commandMap.end())
+	{
+		it->second(); // 함수 실행
+	}
+	else
+	{
+		std::cout << "Unknown Command: " << cmd << std::endl;
+	}
+}
+
+void GameScene::KeyCommandMapping()
+{
+	m_commandMap["Escape"] = [this]()
+		{
+			std::cout << "Escape Command Received: Pausing Game" << std::endl;
+			// 추후 일시정지/재개 로직 여기에
+		};
+
+	m_commandMap["F1"] = [this]()
+		{
+			std::cout << "F1 Command Received: Changing to Title Scene" << std::endl;
+			SceneManager::GetInstance().ChangeScene(std::string("Title"));
+		};
+
+	m_commandMap["F2"] = [this]()
+		{
+			std::cout << "F2 Command Received" << std::endl;
+		};
+
+	m_commandMap["F3"] = [this]()
+		{
+			std::cout << "F3 Command Received" << std::endl;
+		};
+
+	m_commandMap["F4"] = [this]()
+		{
+			std::cout << "F4 Command Received" << std::endl;
+		};
+
+	m_commandMap["Go"] = [this]()
+		{
+			if (m_player) m_player->MoveUp();
+		};
+
+	m_commandMap["Back"] = [this]()
+		{
+			if (m_player) m_player->MoveDown();
+		};
+
+	m_commandMap["Left"] = [this]()
+		{
+			if (m_player) m_player->MoveLeft();
+		};
+
+	m_commandMap["Right"] = [this]()
+		{
+			if (m_player) m_player->MoveRight();
+		};
+}
 

--- a/GameFrameWork/GameScene.h
+++ b/GameFrameWork/GameScene.h
@@ -4,7 +4,8 @@
 class GameScene : public SceneBase { 
 	
 private:
-	
+	Player* m_player = nullptr;
+
 public:
 	//GameScene() = default;
 	GameScene() { std::cout << "Game Scene" << std::endl; }
@@ -16,7 +17,12 @@ public:
 	void LateUpdate(double deltaTime) override;
 	//void Render(Renderer& renderer) override;
 
+	void OnEnter() override;
+
+	void OnLeave() override;
 
 	void OnCommand(std::string& cmd) override;
+
+	void KeyCommandMapping() override;
 
 };

--- a/GameFrameWork/Player.cpp
+++ b/GameFrameWork/Player.cpp
@@ -48,6 +48,16 @@ void Player::LateUpdate(double deltaTime)
 	Object::LateUpdate(deltaTime);
 }
 
+void Player::MoveUp() { Move(0.0f, -1.0f); }
+void Player::MoveDown() { Move(0.0f, 1.0f); }
+void Player::MoveLeft() { Move(-1.0f, 0.0f); }
+void Player::MoveRight() { Move(1.0f, 0.0f); }
 
 
-
+void Player::Move(float dx, float dy)
+{
+	float distance = m_speed;
+	auto pos = m_transform->GetPosition();
+	pos = XMVectorAdd(pos, XMVectorSet(dx * distance, dy * distance, 0, 0));
+	m_transform->SetPosition(pos);
+}

--- a/GameFrameWork/Player.h
+++ b/GameFrameWork/Player.h
@@ -9,6 +9,8 @@ private:
 	BitmapRender* m_bitmapRender = nullptr;
 	Collider2D* m_Collider = nullptr;
 
+	float m_speed = 5.f;
+
 public:
 	Player(float posX, float posY, float width, float height, DirectX::XMFLOAT4 color);
 	virtual ~Player() = default;
@@ -16,6 +18,13 @@ public:
 	void FixedUpdate(double deltaTime) override;
 	void Update(double deltaTime) override;
 	void LateUpdate(double deltaTime) override;
+
+	void Move(float dx, float dy);
+	void MoveUp();
+	void MoveLeft();
+	void MoveDown();
+	void MoveRight();
+
 
 	Transform* GetTransform() { return m_transform; }
 	Collider2D* GetCollider() { return m_Collider; }

--- a/GameFrameWork/TitleScene.cpp
+++ b/GameFrameWork/TitleScene.cpp
@@ -6,7 +6,8 @@
 void TitleScene::Initialize()
 {
 
-	std::cout << "titleScene 초기화 완료" <<std::endl;
+	std::cout << "titleScene Init" <<std::endl;
+	KeyCommandMapping();
 }
 
 void TitleScene::Update(double deltaTime)
@@ -19,7 +20,7 @@ void TitleScene::Update(double deltaTime)
 	if (m_elsapsedTime > 3.0) {
 
 
-		SceneManager::GetInstance().LoadScene(std::string("Game1"));
+		//SceneManager::GetInstance().LoadScene(std::string("Game1"));
 		SceneManager::GetInstance().ChangeScene(std::string("Game1"));
 
 	}
@@ -35,54 +36,59 @@ void TitleScene::Render(Renderer& renderer)
 }
 
 
+void TitleScene::OnEnter()
+{
+
+	std::cout << "Title Scene OnEnter" << std::endl;
+	
+}
+
+void TitleScene::OnLeave()
+{
+	std::cout << "Title Scene Left" << std::endl;
+	Reset();
+}
+
 void TitleScene::OnCommand(std::string& cmd)
 {
-	if (cmd == "Escape")
+	auto it = m_commandMap.find(cmd);
+	if (it != m_commandMap.end())
 	{
-		std::cout << "Escape Command Received: Pausing Game" << std::endl;
-// 		if (m_isPaused)
-// 		{
-// 			Resume();
-// 			std::cout << "Game Resumed" << std::endl;
-// 		}
-// 		else
-// 		{
-// 			Pasued();
-// 			std::cout << "Game Paused" << std::endl;
-// 		}
-	}
-	else if (cmd == "F1")
-	{
-		std::cout << "F1 Command Received" << std::endl;
-	}
-	else if (cmd == "F2")
-	{
-		std::cout << "F2 Command Received" << std::endl;
-	}
-	else if (cmd == "F3")
-	{
-		std::cout << "F3 Command Received" << std::endl;
-// 		if (auto obj = FindObject("Player"))
-// 		{
-// 			if (auto fsm = obj->GetComponent<FSMComponent>())
-// 			{
-// 				fsm->Trigger("RunStop");
-// 			}
-// 			if (auto tf = obj->GetComponent<TransformComponent>())
-// 			{
-// 				tf->SetPosition(200.f, 300.f);
-// 				auto pos = tf->GetPosition();
-// 				std::cout << "Player Pos: " << pos.x << ", " << pos.y << "\n";
-// 			}
-// 		}
-	}
-	else if (cmd == "F4")
-	{
-		std::cout << "F4 Command Received" << std::endl;
+		it->second(); // 함수 실행
 	}
 	else
 	{
 		std::cout << "Unknown Command: " << cmd << std::endl;
 	}
+}
+
+void TitleScene::KeyCommandMapping()
+{
+	m_commandMap["Escape"] = [this]()
+		{
+			std::cout << "Escape Command Received: Pausing Game" << std::endl;
+			// 추후 일시정지/재개 로직 여기에
+		};
+
+	m_commandMap["F1"] = [this]()
+		{
+			std::cout << "F1 Command Received: Changing to Game1 Scene" << std::endl;
+			SceneManager::GetInstance().ChangeScene(std::string("Game1"));
+		};
+
+	m_commandMap["F2"] = []()
+		{
+			std::cout << "F2 Command Received" << std::endl;
+		};
+
+	m_commandMap["F3"] = []()
+		{
+			std::cout << "F3 Command Received" << std::endl;
+		};
+
+	m_commandMap["F4"] = []()
+		{
+			std::cout << "F4 Command Received" << std::endl;
+		};
 }
 

--- a/GameFrameWork/TitleScene.h
+++ b/GameFrameWork/TitleScene.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Engine.h"
+#include "Player.h"
 
 class TitleScene : public SceneBase {
 
@@ -18,8 +19,14 @@ public:
 	//void FixedUpdate(double fixedDeltaTime) override;
 	void Render(Renderer& renderer) override;
 
+	void OnEnter() override;
+
+	void OnLeave() override;
+
 	void OnCommand(std::string& cmd) override;
 
-	//void KeyCommadMapping() ??
+
+	void KeyCommandMapping() override;
+
 
 };


### PR DESCRIPTION
1. F1 버튼 통해 타이틀 <-> 게임 씬 전환 구현
2. OnEnter, OnLeave 함수 추가 (씬, 씬베이스)
3. 게임씬 플레이어 생성 Enter로 이동 >> 이에 따라 Leave함수에서 오브젝트를 초기화 시켜줘야 됨
4. Reset 함수 추가 (씬에 존재하는 모든 객체 삭제)
5. 커맨드맵핑 함수 추가 및 온커맨드 함수 수정
6. 이니셜라이즈 함수 추가 (씬 이니셜라이즈 때 커맨드 맵핑 필요)
7. 커맨드 맵핑 추가 및 GameManager.Initialize에 	SceneManager::GetInstance().InitializeAllScenes();  추가
8. Player에 무브 함수 추가 , 및 게임씬에 플레이어 포인터 추가